### PR TITLE
Convert IDs to lowercase when parsing 

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -21,7 +21,7 @@
     try{
       parsed_map = new Map()
       for(let [k, v] of Object.entries(JSON.parse(extmap))) {
-        parsed_map.set(k.replace(/[^A-Za-z0-9-]/g, '_') + '-browser-action', v)
+        parsed_map.set(k.toLowerCase().replace(/[^A-Za-z0-9-]/g, '_') + '-browser-action', v)
       }
       update_state()
     }catch(e){
@@ -31,7 +31,7 @@
   let hovering = false;
 
   const drop = (event, target) => {
-    event.dataTransfer.dropEffect = 'move'; 
+    event.dataTransfer.dropEffect = 'move';
     const start = parseInt(event.dataTransfer.getData("text/plain"));
     const newTracklist = extlist
 
@@ -78,8 +78,8 @@ console.log(JSON.stringify(data))
 {#if extlist.length > 0}
   <div class="list">
   {#each extlist as n, index (n.key)}
-    <div class="list-item" 
-       draggable={true} 
+    <div class="list-item"
+       draggable={true}
        on:dragstart={event => dragstart(event, index)}
        on:drop|preventDefault={event => drop(event, index)}
        ondragover="return false"


### PR DESCRIPTION
Hi, I found this repo through Bugzilla, thanks for posting it there! I found an edge case where some extensions' names weren't found, and figured out it was due to case mismatches.

This fixes e.g. Honey, which has uppercase letters in its ID: https://addons.mozilla.org/en-US/firefox/addon/honey/